### PR TITLE
Update F7HardwareRevision enum

### DIFF
--- a/Source/Meadow.Contracts/Hardware/F7HardwareRevision.cs
+++ b/Source/Meadow.Contracts/Hardware/F7HardwareRevision.cs
@@ -1,16 +1,19 @@
 ﻿namespace Meadow.Hardware
 {
+    /// <summary>
+    /// Meadow Form Factors
+    /// </summary>
     public enum F7HardwareRevision
     {
         /// <summary>
-        /// F7 Micro version 1 (revisions a -> d).
+        /// F7 Feather Version 1 (revisions a -> d).
         /// </summary>
-        F7MicroV1 = 1,
+        F7FeatherV1 = 1,
 
         /// <summary>
-        /// F7 Micro version 2 (revisions a -> c).
+        /// F7 Feather Version 2 (revisions a -> c).
         /// </summary>
-        F7MicroV2 = 2,
+        F7FeatherV2 = 2,
 
         /// <summary>
         /// F7 Core Compute Module.


### PR DESCRIPTION
I wonder if we should call **F7CoreCompute** => **F7CoreComputeV1**  since I'm sure we'll release multiple versions in the future, and we wont need to do any renaming.