### PR TITLE
Remove unused OnShutdown params

### DIFF
--- a/Source/Meadow.Contracts/Hardware/Contracts/IApp.cs
+++ b/Source/Meadow.Contracts/Hardware/Contracts/IApp.cs
@@ -23,7 +23,7 @@
         /// <summary>
         /// Called if the app is being brought down.
         /// </summary>
-        public void OnShutdown(out bool complete, Exception? e = null);
+        public void OnShutdown();
 
         /// <summary>
         /// Called if a failure occured while running the app


### PR DESCRIPTION
[Required for WildernessLabs/Meadow.Core#190]

After a discussion with @ctacke, it seems the [two parameters for `OnShutdown` aren't being used](https://github.com/WildernessLabs/Meadow.Core/blob/afae56e569186aafffd5bb3506abddc604b937c0/source/Meadow.Core/MeadowOS.cs#L73-L92) internally. This would remove them to avoid having to document their [lack of] use in the upcoming application lifecycle events reference.