### PR TITLE
Fix various comment warnings and typos.

### DIFF
--- a/Source/Meadow.Contracts/Enums/AntennaType.cs
+++ b/Source/Meadow.Contracts/Enums/AntennaType.cs
@@ -1,8 +1,8 @@
 ﻿namespace Meadow.Hardware
 {
-    // <summary>
-    // The types of antenna that can be selected.
-    // </summary>
+    /// <summary>
+    /// The types of antenna that can be selected.
+    /// </summary>
     public enum AntennaType
     {
         NotKnown = 0,

--- a/Source/Meadow.Contracts/Enums/ChannelConfigurationType.cs
+++ b/Source/Meadow.Contracts/Enums/ChannelConfigurationType.cs
@@ -2,7 +2,7 @@
 {
     /// <summary>
     /// TODO: revisit this structure. Ultimately, it would be nice to know, specifically
-    /// what a channel is cofigured for, i.e. DigitalInput, I2C TX, UART RX, etc.
+    /// what a channel is configured for, i.e. DigitalInput, I2C TX, UART RX, etc.
     /// </summary>
     public enum ChannelConfigurationType
     {

--- a/Source/Meadow.Contracts/Enums/ConnectionStatus.cs
+++ b/Source/Meadow.Contracts/Enums/ConnectionStatus.cs
@@ -36,9 +36,9 @@
         /// </summary>
         Timeout = 5,
 
-        /// <summary>
-        /// Connection failed because the authentication protocol is not supported.
-        /// </summary>
+        ///// <summary>
+        ///// Connection failed because the authentication protocol is not supported.
+        ///// </summary>
         //UnsupportedAuthenticationProtocol = 6
 
         /// <summary>

--- a/Source/Meadow.Contracts/Gateways/ICoprocessor.cs
+++ b/Source/Meadow.Contracts/Gateways/ICoprocessor.cs
@@ -42,7 +42,7 @@ namespace Meadow.Gateways
             PowerOn = 1,
 
             /// <summary>
-            /// External GPIO has woken the coprocessof from sleep.
+            /// External GPIO has woken the coprocessor from sleep.
             /// </summary>
             ExternalGpio = 2,
 

--- a/Source/Meadow.Contracts/Hardware/Contracts/IApp.cs
+++ b/Source/Meadow.Contracts/Hardware/Contracts/IApp.cs
@@ -28,7 +28,7 @@
         public void OnShutdown();
 
         /// <summary>
-        /// Called if a failure occured while running the app
+        /// Called if a failure occurred while running the app
         /// </summary>
         public void OnError(Exception e, out bool recovered);
 

--- a/Source/Meadow.Contracts/Hardware/Contracts/IPinDefinitions.cs
+++ b/Source/Meadow.Contracts/Hardware/Contracts/IPinDefinitions.cs
@@ -12,7 +12,7 @@ namespace Meadow.Hardware
     public interface IPinDefinitions : IEnumerable<IPin>
     {
         /// <summary>
-        /// Convenience property which contains all the pins avaiable on the 
+        /// Convenience property which contains all the pins available on the 
         /// device.
         /// </summary>
         /// <value>All the pins.</value>

--- a/Source/Meadow.Contracts/Hardware/Contracts/PortsAndBuses/IDigitalOutputPort.cs
+++ b/Source/Meadow.Contracts/Hardware/Contracts/PortsAndBuses/IDigitalOutputPort.cs
@@ -4,7 +4,7 @@ namespace Meadow.Hardware
     public interface IDigitalOutputPort : IDigitalPort
     {
         /// <summary>
-        /// Gets the port’s initial state, either low (false), or high (true), as typically configured during the port’s constructor.
+        /// Gets the port's initial state, either low (false), or high (true), as typically configured during the port's constructor.
         /// </summary>
         bool InitialState { get; }
         /// <summary>

--- a/Source/Meadow.Contracts/Hardware/DigitalPortResult.cs
+++ b/Source/Meadow.Contracts/Hardware/DigitalPortResult.cs
@@ -18,7 +18,7 @@ namespace Meadow.Hardware
         }
         /// <summary>
         /// The duration of time in between the time the event or notification
-        /// ocurred, and the the time it occured before.
+        /// ocurred, and the the time it occurred before.
         /// </summary>
         public TimeSpan? Delta {
             get => New.Time - Old?.Time;

--- a/Source/Meadow.Contracts/Hardware/IDeviceInformation.cs
+++ b/Source/Meadow.Contracts/Hardware/IDeviceInformation.cs
@@ -32,7 +32,7 @@
         string ProcessorSerialNumber { get; }
 
         /// <summary>
-        /// Get the unique ID of the micrcontroller.
+        /// Get the unique ID of the microcontroller.
         /// </summary>
         /// <returns>Unique ID of the microcontroller.</returns>
         string ChipID { get; }

--- a/Source/Meadow.Contracts/Hardware/SerialMessageData.cs
+++ b/Source/Meadow.Contracts/Hardware/SerialMessageData.cs
@@ -4,7 +4,7 @@ using System.Text;
 namespace Meadow.Hardware
 {
     /// <summary>
-    /// Represents a `SerialMessagePort` message consiting of a `byte[]` of the
+    /// Represents a `SerialMessagePort` message consisting of a `byte[]` of the
     /// actual message data.
     /// </summary>
     public class SerialMessageData : EventArgs

--- a/Source/Meadow.Contracts/Peripherals/Displays/ITextDisplay.cs
+++ b/Source/Meadow.Contracts/Peripherals/Displays/ITextDisplay.cs
@@ -21,6 +21,7 @@
         /// </summary>
         /// <param name="text">String to display.</param>
         /// <param name="lineNumber">Line Number.</param>
+        /// <param name="showCursor">Show the cursor.</param>
         void WriteLine(string text, byte lineNumber, bool showCursor = false);
 
         /// <summary>
@@ -35,14 +36,14 @@
         void ClearLine(byte lineNumber);
 
         /// <summary>
-        /// Set cursor in the especified row and column.
+        /// Set cursor in the specified row and column.
         /// </summary>
         /// <param name="column"></param>
         /// <param name="line"></param>
         void SetCursorPosition(byte column, byte line);
 
         /// <summary>
-        /// Update the display, not used by character dislays
+        /// Update the display, not used by character displays
         /// </summary>
         void Show();
 

--- a/Source/Meadow.Contracts/Peripherals/Sensors/Location/Gnss/ActiveSatelliteSelection.cs
+++ b/Source/Meadow.Contracts/Peripherals/Sensors/Location/Gnss/ActiveSatelliteSelection.cs
@@ -3,7 +3,7 @@
 namespace Meadow.Peripherals.Sensors.Location.Gnss
 {
     /// <summary>
-    /// Active satelite selection for GSA messages.
+    /// Active satellite selection for GSA messages.
     /// </summary>
     public enum ActiveSatelliteSelection
     {

--- a/Source/Meadow.Contracts/Peripherals/Sensors/Location/Gnss/ActiveSatellites.cs
+++ b/Source/Meadow.Contracts/Peripherals/Sensors/Location/Gnss/ActiveSatellites.cs
@@ -19,7 +19,7 @@ namespace Meadow.Peripherals.Sensors.Location.Gnss
         public string TalkerID { get; set; } = "GP";
 
         /// <summary>
-        /// Retreives the full name associated with the TalkerID via the
+        /// Retrieves the full name associated with the TalkerID via the
         /// `KnownTalkerIDs` property of the Lookups class.
         /// </summary>
         public string TalkerSystemName {

--- a/Source/Meadow.Contracts/Peripherals/Sensors/Location/Gnss/CourseOverGround.cs
+++ b/Source/Meadow.Contracts/Peripherals/Sensors/Location/Gnss/CourseOverGround.cs
@@ -19,7 +19,7 @@ namespace Meadow.Peripherals.Sensors.Location.Gnss
         public string TalkerID { get; set; } = "GP";
 
         /// <summary>
-        /// Retreives the full name associated with the TalkerID via the
+        /// Retrieves the full name associated with the TalkerID via the
         /// `KnownTalkerIDs` property of the Lookups class.
         /// </summary>
         public string TalkerSystemName {
@@ -62,7 +62,7 @@ namespace Meadow.Peripherals.Sensors.Location.Gnss
             outString.Append($"\tTalker ID: {TalkerID}, talker name: {TalkerSystemName}\r\n");
             outString.Append($"\tTime of reading: {TimeOfReading}\r\n");
             outString.Append($"\tTrue Heading: {TrueHeading}\r\n");
-            outString.Append($"\tMagentic Heading: {MagneticHeading}\r\n");
+            outString.Append($"\tMagnetic Heading: {MagneticHeading}\r\n");
             outString.Append($"\tKnots: {Knots:f2}\r\n");
             outString.Append($"\tKph: {Kph:f2}\r\n");
             outString.Append("}");

--- a/Source/Meadow.Contracts/Peripherals/Sensors/Location/Gnss/GnssPositionInfo.cs
+++ b/Source/Meadow.Contracts/Peripherals/Sensors/Location/Gnss/GnssPositionInfo.cs
@@ -19,7 +19,7 @@ namespace Meadow.Peripherals.Sensors.Location.Gnss
         public string TalkerID { get; set; } = "GP";
 
         /// <summary>
-        /// Retreives the full name associated with the TalkerID via the
+        /// Retrieves the full name associated with the TalkerID via the
         /// `KnownTalkerIDs` property of the Lookups class.
         /// </summary>
         public string TalkerSystemName {

--- a/Source/Meadow.Contracts/Peripherals/Sensors/Location/Gnss/SatellitesInView.cs
+++ b/Source/Meadow.Contracts/Peripherals/Sensors/Location/Gnss/SatellitesInView.cs
@@ -15,7 +15,7 @@ namespace Meadow.Peripherals.Sensors.Location.Gnss
         public string TalkerID { get; set; } = "GP";
 
         /// <summary>
-        /// Retreives the full name associated with the TalkerID via the
+        /// Retrieves the full name associated with the TalkerID via the
         /// `KnownTalkerIDs` property of the Lookups class.
         /// </summary>
         public string TalkerSystemName {

--- a/Source/Meadow.Contracts/Peripherals/Sensors/Weather/IAnemometer.cs
+++ b/Source/Meadow.Contracts/Peripherals/Sensors/Weather/IAnemometer.cs
@@ -6,7 +6,7 @@ namespace Meadow.Peripherals.Sensors.Weather
     public interface IAnemometer : ISensor
     {
         /// <summary>
-        /// The last recored wind speed.
+        /// The last recorded wind speed.
         /// </summary>
         Speed? WindSpeed { get; }
 


### PR DESCRIPTION
Mostly intended to fix a couple XML comment build warnings, but found a bunch of spelling errors. Should be only non-code changes that won't change any APIs, either internal or external-facing. (AKA shouldn't be any breaking changes for us or users.)

There are still a lot of elements that are complaining about needing a `/// <summary>`, but I didn't have enough context/subject-expertise to add those.