### PR TITLE
Fix private and protected code typos

### DIFF
--- a/Source/Meadow.Contracts/FilterableChangeObserver.cs
+++ b/Source/Meadow.Contracts/FilterableChangeObserver.cs
@@ -26,7 +26,7 @@ namespace Meadow
         /// property on the result, because this only gets updated if the filter
         /// is satisfied and the result is sent to the observer.
         /// </summary>
-        protected UNIT? lastNotifedValue;
+        protected UNIT? lastNotifiedValue;
 
         /// <summary>
         /// Creates a new `FilterableChangeObserver` that will execute the handler
@@ -53,7 +53,7 @@ namespace Meadow
         {
             // if the last notified value isn't null, inject it into the result.
             // (each last notified is specific to the observer)
-            if (lastNotifedValue is { } last) {
+            if (lastNotifiedValue is { } last) {
                 result.Old = last;
             }
 
@@ -65,7 +65,7 @@ namespace Meadow
             if (Filter == null || Filter(result) || result.Old is null)
             {
                 // save the last notified value as this new value
-                lastNotifedValue = result.New;
+                lastNotifiedValue = result.New;
                 // invoke (execute) the handler
                 Handler?.Invoke(result);
             }

--- a/Source/Meadow.Contracts/Hardware/ServiceCollection.cs
+++ b/Source/Meadow.Contracts/Hardware/ServiceCollection.cs
@@ -184,7 +184,7 @@ namespace Meadow
             object? instance;
             if (ctor == null)
             {
-                instance = DoContructorInjections(ctors);
+                instance = DoConstructorInjections(ctors);
             }
             else
             {
@@ -202,7 +202,7 @@ namespace Meadow
             return instance;
         }
 
-        private object? DoContructorInjections(IEnumerable<ConstructorInfo> ctors)
+        private object? DoConstructorInjections(IEnumerable<ConstructorInfo> ctors)
         {
             List<object> pList = new List<object>();
 


### PR DESCRIPTION
Similar to #35, but typos in code that _might_ impact consuming code.

One change is `protected`; the other `private`, so it should be unlikely.