### PR TITLE
Adjust cell network connection name

### DIFF
--- a/Source/Meadow.Contracts/Platform OS/IPlatformOS.Configuration.cs
+++ b/Source/Meadow.Contracts/Platform OS/IPlatformOS.Configuration.cs
@@ -51,9 +51,9 @@
             /// </summary>
             Ethernet,
             /// <summary>
-            /// GSM network connection
+            /// Cell network connection
             /// </summary>
-            GSM
+            Cell
         }
 
 


### PR DESCRIPTION
**Summary**
Just to adjust the network name, since Cell will not use necessarily GSM, it can use other network technologies, such as LTE-M (Cat-M1) or NB-IoT, for example.

This PR is related to a change on [Meadow.Core](https://github.com/WildernessLabs/Meadow.Core/pull/333).