### PR TITLE
add metadata field for Update

### DIFF
--- a/Source/Meadow.Contracts/Update/UpdateInfo.cs
+++ b/Source/Meadow.Contracts/Update/UpdateInfo.cs
@@ -47,5 +47,9 @@ namespace Meadow.Update
         /// The expected Hash of the Update package
         /// </summary>
         public string DownloadHash { get; set; } = string.Empty;
+        /// <summary>
+        /// Metadata for the package
+        /// </summary>
+        public string Metadata { get; set; }
     }
 }

--- a/Source/Meadow.Contracts/Update/UpdateMessage.cs
+++ b/Source/Meadow.Contracts/Update/UpdateMessage.cs
@@ -18,10 +18,5 @@
         /// Gets or sets the download URL of the MPak.
         /// </summary>
         public string MpakDownloadUrl { get; set; }
-
-        /// <summary>
-        /// Gets or sets the target devices for the update.
-        /// </summary>
-        public string[] TargetDevices { get; set; }
     }
 }


### PR DESCRIPTION
* add `Metadata` field for UpdateInfo. This field is a passthrough from the user when publishing a package. This optional field can be used by the device to determine if the update should be applied or not.
* removed `TargetDevices`. This was a POC and no longer used.

Test output:
```
Meadow StdOut: MQTT message received
Meadow StdOut: Updater Message Received: 7aedf4b3e304482e97f2a43041ebc30b
Meadow StdOut: Update available! meta: my metadata
```