### PR TITLE
Update NetworkAuthenticationType.cs

### DIFF
--- a/Contributing.md
+++ b/Contributing.md
@@ -20,9 +20,9 @@
 2. Clone your fork locally: `git clone https://github.com/WildernessLabs/Meadow.Contracts`
 3. Switch to the `develop` branch
 4. Create a new branch: `git checkout -b feature/your-contribution`
-5. Make your changes and commit: `git commit -m 'Added/Updated [feature/fix]`
+5. Make your changes and commit: `git commit -m 'Added/Updated [feature/fix]'`
 6. Push to your fork: `git push origin feature/your-contribution`
-7. Open a pull request at [Meadow.Contracts/pulls](https://github.com/WildernessLabs/Meadow.Contracts/pulls) targetting the `develop` branch
+7. Open a pull request at [Meadow.Contracts/pulls](https://github.com/WildernessLabs/Meadow.Contracts/pulls) targeting the `develop` branch
 ## Need Help?
 
 If you have questions or need assistance, please join the Wilderness Labs [community on Slack](http://slackinvite.wildernesslabs.co/).

--- a/Source/Meadow.Contracts/Enums/NetworkAuthenticationType.cs
+++ b/Source/Meadow.Contracts/Enums/NetworkAuthenticationType.cs
@@ -44,13 +44,17 @@ public enum NetworkAuthenticationType
     /// Open authentication over 802.11 wireless. Devices are authenticated and can connect to an
     /// access point, but communication with the network requires a matching Wired Equivalent Privacy (WEP) key.
     /// </summary>
-    Open80211 = 6,
+    /// <summary>
+    /// Specifies a Wi-Fi Protected Access 3 (WPA3) algorithm that uses pre-shared keys (PSK). IEEE 802.1X port
+    /// authorization is performed by the supplicant and authenticator. Cipher keys are dynamically derived
+    /// through a pre-shared key that is used on both the supplicant and authenticator.
+    /// </summary>
+    Wpa3Psk = 6,
 
     /// <summary>
-    /// Specifies an IEEE 802.11 Shared Key authentication algorithm that requires the use of a pre-shared
-    /// Wired Equivalent Privacy (WEP) key for the 802.11 authentication.
+    /// WPA2 PSK or WPA3 PSK mixed-mode encryption.
     /// </summary>
-    SharedKey80211 = 7,
+    WpaWpa3Psk = 7,
 
     /// <summary>
     /// Specifies a Wi-Fi Protected Access (WPA) algorithm. IEEE 802.1X port authorization is performed by
@@ -60,7 +64,7 @@ public enum NetworkAuthenticationType
     Wpa = 8,
 
     /// <summary>
-    /// Wi-Fi Protected Access.
+    /// Wi-Fi Protected Access with no authentication server.
     /// </summary>
     WpaNone = 9,
 
@@ -84,20 +88,19 @@ public enum NetworkAuthenticationType
     Ihv = 12,
 
     /// <summary>
-    /// Specifies a Wi-Fi Protected Access 3 (WPAs) algorithm that uses pre-shared keys (PSK). IEEE 802.1X port
-    /// authorization is performed by the supplicant and authenticator. Cipher keys are dynamically derived
-    /// through a pre-shared key that is used on both the supplicant and authenticator.
+    /// Open authentication over 802.11 wireless.
     /// </summary>
-    Wpa3Psk = 13,
+    Open80211 = 13,
 
     /// <summary>
-    /// WPA PSK or WPA3 PSk encryption.
+    /// Specifies an IEEE 802.11 Shared Key authentication algorithm that requires the use of a pre-shared
+    /// Wired Equivalent Privacy (WEP) key for the 802.11 authentication.
     /// </summary>
-    WpaWap3Psk = 14,
+    SharedKey80211 = 14,
 
     /// <summary>
     /// Unknown authentication type.
     /// </summary>
-    Unknown = 1
+    Unknown = 255
 
 }


### PR DESCRIPTION
The ESP32 firmware returns a WiFiAuthenticationMode value that gets cast directly to NetworkAuthenticationType. The original enum had misaligned values
  above index 5, so specific auth types were being misidentified:

  - Unknown = 1 collided with Wep = 1 — so any network the ESP32 didn't recognize came back as WEP
  - Wpa3Psk was 13 in Contracts but the ESP32 firmware returns 6 for it — so WPA3 networks showed as Open80211 (which was 6)
  - WpaWpa3Psk was 14 in Contracts but ESP32 returns 7 — same problem

  The fix was to realign the Contracts enum so values 0–7 match the ESP32 firmware's WiFiAuthenticationMode directly (enabling a simple cast with no mapping needed), and
  move Unknown to 255 to get it out of the way.
